### PR TITLE
Readme and Vignette Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ contains 434 agonistic interaction datasets, totaling over 241,000 interactions.
 
 To install the package with the vignette, run (requires `devtools` package):  
 
-`devtools::install_github(‘DomArchive/DomArchive', build_vignettes = TRUE)`    
+`devtools::install_github("DomArchive/DomArchive", build_vignettes = TRUE)`    
 
 To view an introductory vignette about how to use the package, run:  
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -155,7 +155,7 @@ we will use the `dci()` function in the `compete` R package. To install `compete
 ```{r}
 ## Install compete if not available
 if(!"compete" %in% rownames(installed.packages()))
-  devtools::install_github("jalapic/compete")
+  install_version("compete", version = "0.0.1", repos = "http://cran.us.r-project.org")
 
 captivity <- data.frame(dci = purrr::map_dbl(primates.captive, compete::dci),
                         num.ids = purrr::map_dbl(primates.captive, nrow))

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -159,8 +159,8 @@ we will use the `dci()` function in the `compete` R package. To install `compete
 ## Install compete if not available
 if(!"igraph" %in% rownames(installed.packages()))
   install.packages("igraph", repos = "http://cran.us.r-project.org")
-if(!"sna" %in% rownames(installed.packages()), repos = "http://cran.us.r-project.org")
-  install.packages("sna")
+if(!"sna" %in% rownames(installed.packages()))
+  install.packages("sna", repos = "http://cran.us.r-project.org")
 if(!"compete" %in% rownames(installed.packages()))
   install_version("compete", version = "0.1", repos = "http://cran.us.r-project.org")
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -128,7 +128,7 @@ do this with `subset_archive()` using both approaches described above.
 
 ```{r}
 if(!"dplyr" %in% rownames(installed.packages()))
-  install.packages("dplyr")
+  install.packages("dplyr", repos = "http://cran.us.r-project.org")
 
 ## Option 1 - using fileids
 captive.fileids <- subset(dom.metadata, order == 'Primates' & captivity == 'Captive' & countbinary == 'Count' & matrix_edgelist == 'Matrix')$fileid
@@ -158,8 +158,8 @@ we will use the `dci()` function in the `compete` R package. To install `compete
 ```{r}
 ## Install compete if not available
 if(!"igraph" %in% rownames(installed.packages()))
-  install.packages("igraph")
-if(!"sna" %in% rownames(installed.packages()))
+  install.packages("igraph", repos = "http://cran.us.r-project.org")
+if(!"sna" %in% rownames(installed.packages()), repos = "http://cran.us.r-project.org")
   install.packages("sna")
 if(!"compete" %in% rownames(installed.packages()))
   install_version("compete", version = "0.1", repos = "http://cran.us.r-project.org")

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -127,6 +127,9 @@ First, we will restrict the dataset to only primates using the `order` column. H
 do this with `subset_archive()` using both approaches described above. 
 
 ```{r}
+if(!"dplyr" %in% rownames(installed.packages()))
+  install.packages("dplyr")
+
 ## Option 1 - using fileids
 captive.fileids <- subset(dom.metadata, order == 'Primates' & captivity == 'Captive' & countbinary == 'Count' & matrix_edgelist == 'Matrix')$fileid
 primates.captive <- subset_archive(fileids = captive.fileids, return.intxdata.only = TRUE)
@@ -154,8 +157,12 @@ we will use the `dci()` function in the `compete` R package. To install `compete
 
 ```{r}
 ## Install compete if not available
+if(!"igraph" %in% rownames(installed.packages()))
+  install.packages("igraph")
+if(!"sna" %in% rownames(installed.packages()))
+  install.packages("sna")
 if(!"compete" %in% rownames(installed.packages()))
-  install_version("compete", version = "0.0.1", repos = "http://cran.us.r-project.org")
+  install_version("compete", version = "0.1", repos = "http://cran.us.r-project.org")
 
 captivity <- data.frame(dci = purrr::map_dbl(primates.captive, compete::dci),
                         num.ids = purrr::map_dbl(primates.captive, nrow))


### PR DESCRIPTION
The readme file contains (‘) in devtools::install_github(‘DomArchive/DomArchive', build_vignettes = TRUE), not directly copy paste use for the end user, the vignette builds fail due to assumption that the user already has "dplyr" package and additionally the "compete" repository is removed. 

The update fix both issues.